### PR TITLE
Update projects.json

### DIFF
--- a/res/data/projects.json
+++ b/res/data/projects.json
@@ -85,7 +85,7 @@
             "price": "Free"
         },
         "Numix uTouch": {
-            "url": "http://fav.me/d6fo94s",
+            "url": "https://github.com/numixproject/numix-icon-theme-utouch",
             "code": "http://github.com/numixproject/numix-icon-theme-utouch",
             "thumbnail": "thumb4.jpg",
             "price": "Free"


### PR DESCRIPTION
Since the link for Numix uTouch to DevientArt doesn't work anymore, would not be nice to replace it to a redirection to the Github's page of the repository?
